### PR TITLE
jetbrains.buildServer.clouds.CloudImage#getAgentPoolId must return null or actual agent pool id

### DIFF
--- a/cloud-openstack-server/src/main/java/jetbrains/buildServer/clouds/openstack/OpenstackCloudImage.java
+++ b/cloud-openstack-server/src/main/java/jetbrains/buildServer/clouds/openstack/OpenstackCloudImage.java
@@ -122,7 +122,7 @@ public class OpenstackCloudImage implements CloudImage {
     @Nullable
     @Override
     public Integer getAgentPoolId() {
-        return 0;
+        return null;
     }
 
     @Nullable


### PR DESCRIPTION
jetbrains.buildServer.clouds.CloudImage#getAgentPoolId must return null or actual agent pool id (if this functionality is used). 0 means Default pool, so every time TC initializes the cloud client the image will be pushed back to Default pool