### PR TITLE
Catch exception and forget instance when trying to update status failed

### DIFF
--- a/cloud-openstack-server/src/main/java/jetbrains/buildServer/clouds/openstack/OpenstackCloudImage.java
+++ b/cloud-openstack-server/src/main/java/jetbrains/buildServer/clouds/openstack/OpenstackCloudImage.java
@@ -70,8 +70,9 @@ public class OpenstackCloudImage implements CloudImage {
         this.executor.scheduleWithFixedDelay(new VerboseRunnable(() -> {
             for (OpenstackCloudInstance instance : getInstances()) {
                 instance.updateStatus();
-                if (instance.getStatus() == InstanceStatus.STOPPED || instance.getStatus() == InstanceStatus.ERROR)
+                if (instance.getStatus() == InstanceStatus.STOPPED || instance.getStatus() == InstanceStatus.ERROR) {
                     forgetInstance(instance);
+                }
             }
         }, true), 3, 3, TimeUnit.SECONDS);
     }

--- a/cloud-openstack-server/src/test/resources/__files/v2.1-nova-id-servers-server-id-not-defined.json
+++ b/cloud-openstack-server/src/test/resources/__files/v2.1-nova-id-servers-server-id-not-defined.json
@@ -1,0 +1,52 @@
+{
+    "server": {
+        "OS-EXT-STS:task_state": null,
+        "addresses": {
+            "test_network": [
+                {
+                    "OS-EXT-IPS-MAC:mac_addr": "00:00:00:00:00:00",
+                    "version": 4,
+                    "addr": "192.168.1.42",
+                    "OS-EXT-IPS:type": "fixed"
+                },
+                {
+                    "OS-EXT-IPS-MAC:mac_addr": "00:00:00:00:00:00",
+                    "version": 4,
+                    "addr": "10.248.7.42",
+                    "OS-EXT-IPS:type": "floating"
+                }
+            ]
+        },
+        "image": {
+            "id": "image-id"
+        },
+        "OS-EXT-STS:vm_state": "active",
+        "OS-SRV-USG:launched_at": null,
+        "flavor": {
+            "id": "flavor-id"
+        },
+
+        "user_id": "user-id",
+        "OS-DCF:diskConfig": "MANUAL",
+        "accessIPv4": "10.248.7.42",
+        "accessIPv6": "",
+        "progress": 0,
+        "OS-EXT-STS:power_state": 0,
+        "OS-EXT-AZ:availability_zone": "",
+        "config_drive": "",
+        "status": "ACTIVE",
+        "updated": "2019-10-31T08:49:21Z",
+        "hostId": "",
+        "OS-SRV-USG:terminated_at": null,
+        "key_name": "test_key_pair",
+        "name": "openstack-test-teamcity-plugin-4242424242",
+        "created": "2019-10-31T08:49:21Z",
+        "tenant_id": "tenant-id",
+        "os-extended-volumes:volumes_attached": [
+        ],
+        "metadata": {
+            "agent.cloud.ip": "10.248.7.42",
+            "teamcity.cloud.agent.remove.policy": "remove"
+        }
+    }
+}


### PR DESCRIPTION
There's an NPE inside the nova library, which in the long run leads to leaking instances. Leaked instances, however, are still getting counted in limits. This commit fixes this issue.