### PR TITLE
added "secure:" prefix for password

### DIFF
--- a/cloud-openstack-common/src/main/java/jetbrains/buildServer/clouds/openstack/OpenstackCloudParameters.java
+++ b/cloud-openstack-common/src/main/java/jetbrains/buildServer/clouds/openstack/OpenstackCloudParameters.java
@@ -1,5 +1,7 @@
 package jetbrains.buildServer.clouds.openstack;
 
+import jetbrains.buildServer.agent.Constants;
+
 public final class OpenstackCloudParameters {
 
     private OpenstackCloudParameters() {
@@ -12,7 +14,7 @@ public final class OpenstackCloudParameters {
 
     public static final String ENDPOINT_URL = "clouds.openstack.endpointUrl";
     public static final String IDENTITY = "clouds.openstack.identity";
-    public static final String PASSWORD = "clouds.openstack.password"; // NOSONAR: No clear password
+    public static final String PASSWORD = Constants.SECURE_PROPERTY_PREFIX + "clouds.openstack.password"; // NOSONAR: No clear password
     public static final String REGION = "clouds.openstack.zone";
     public static final String INSTANCE_CAP = "clouds.openstack.instanceCap";
 


### PR DESCRIPTION
Without the prefix, the settings are saved as they are and are available as plain text in the Kotlin DSL.
The prefix also allows security tokens such as credentialsJSON:<id> for passwords.

The auto-generated patches in Kotlin DSL without prefix look like
```
changeProject(RelativeId("Openstack")) {
    features {
        val feature1 = find<ProjectFeature> {
            feature {
                type = "CloudProfile"
                id = "NOVA-1"
...
            }
        }
        feature1.apply {
            param("clouds.openstack.password", "blabla")
        }
    }
}
```