### PR TITLE
Support Teamcity 2020.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <version>1.5-SNAPSHOT</version>
     <packaging>pom</packaging>
     <properties>
-        <teamcity.version>2020.1.1</teamcity.version>
+        <teamcity.version>2020.2.2</teamcity.version>
         <jclouds.version>2.2.1</jclouds.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Update dependencies to support teamcity 2020.2.2

On teamcity 2020.2.2 plugin can't load agent side stuff

How to reproduce:
1. Run teamcity server and agent 2020.2.2
2. Install openstack-cloud plugin version 1.4
3. find plugin initialization errors in agent logs
```
[2021-02-25 14:25:52,557]   WARN - inLoader$TeamCityPluginContext - Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'jetbrains.buildServer.clouds.openstack.OpenstackAgentProperties#0' defined in Byte array resource [plugin: cloud-openstack-agent#cloud-openstack-agent-1.4.jar!/META-INF/build-agent-plugin-cloud-openstack.xml]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'jetbrains.buildServer.util.EventDispatcher<jetbrains.buildServer.agent.AgentLifeCycleAdapter>' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
[2021-02-25 14:25:52,588]  ERROR - gins.spring.SpringPluginLoader - Error loading plugin 'cloud-openstack-agent': Failed to initialize spring context: Error creating bean with name 'jetbrains.buildServer.clouds.openstack.OpenstackAgentProperties#0' defined in Byte array resource [plugin: cloud-openstack-agent#cloud-openstack-agent-1.4.jar!/META-INF/build-agent-plugin-cloud-openstack.xml]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'jetbrains.buildServer.util.EventDispatcher<jetbrains.buildServer.agent.AgentLifeCycleAdapter>' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'jetbrains.buildServer.clouds.openstack.OpenstackAgentProperties#0' defined in Byte array resource [plugin: cloud-openstack-agent#cloud-openstack-agent-1.4.jar!/META-INF/build-agent-plugin-cloud-openstack.xml]: Unsatisfied dependency expressed through constructor parameter 1; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'jetbrains.buildServer.util.EventDispatcher<jetbrains.buildServer.agent.AgentLifeCycleAdapter>' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:749)
	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:189)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1196)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1098)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:511)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:481)
	at org.springframework.beans.factory.support.AbstractBeanFactory$1.getObject(AbstractBeanFactory.java:312)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:230)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:308)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:197)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:757)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:867)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:542)
	at jetbrains.buildServer.plugins.spring.SpringPluginLoader.pluginClassesLoaded(SpringPluginLoader.java:123)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at jetbrains.buildServer.util.EventDispatcher$3.run(EventDispatcher.java:138)
	at jetbrains.buildServer.util.NamedThreadFactory.executeWithNewThreadName(NamedThreadFactory.java:76)
	at jetbrains.buildServer.util.EventDispatcher.dispatch(EventDispatcher.java:132)
	at jetbrains.buildServer.util.EventDispatcher$2.invoke(EventDispatcher.java:82)
	at com.sun.proxy.$Proxy11.pluginClassesLoaded(Unknown Source)
	at jetbrains.buildServer.plugins.PluginManagerImpl$5.visitPlugin(PluginManagerImpl.java:422)
	at jetbrains.buildServer.plugins.PluginsCollection$1.run(PluginsCollection.java:98)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'jetbrains.buildServer.util.EventDispatcher<jetbrains.buildServer.agent.AgentLifeCycleAdapter>' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.raiseNoMatchingBeanFound(DefaultListableBeanFactory.java:1490)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1101)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1063)
	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:835)
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:741)
	... 29 more
```

I used this compose.yml for testing
```
version: "3"
services:
  server:
    image: jetbrains/teamcity-server:2020.2.2
    ports:
      - "8112:8111"
  teamcity-agent:
    image: jetbrains/teamcity-agent:2020.2.2
    environment:
      - SERVER_URL=http://server:8111
      - AGENT_NAME=regular_agent

```